### PR TITLE
Update aggregator get /shares description

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Receives tasks (with twitter access token attached) from the hub, manages rate l
 Data store of all urls being shared, includes timestamp data of which users shared it and can answer questions like
 * POST /shares {provider: 'twitter', link: 'some-url', editor: 'username', shared_at: timestamp} #add share to store
 * GET /article?url=some-urlencoded-url #returns time series of editor details
-* GET /shares/:editor_id/:provider #all the shares from an editor (provider is optional e.g. twitter, reddit etc.)
+* GET /shares?editor=some-username #all the shares from an editor  
 
 ### Ranker
 Analyse shares in the aggregator and give points to users based on their sharing activity


### PR DESCRIPTION
I want to change the url of the aggregator's get /shares url to use a query string for searching my username. The mongo db doesn't have a user table at the moment and so searching by user_id doesn't make any sense.
